### PR TITLE
Add skill-specific hiscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Get list of recently searched players.
 ### GET /api/mock
 Get mock hiscores data for testing.
 
+### GET /api/leaderboard/{skill}
+Retrieve leaderboard data for a specific skill. `{skill}` should match one of the game skills such as `Agility` or `Fishing`.
+
+**Response:**
+```json
+[
+  { "rank": 1, "username": "Player1", "level": 99, "xp": 13034431 },
+  { "rank": 2, "username": "Player2", "level": 98, "xp": 12000000 }
+]
+```
+
 ## Development
 
 ### Local Development


### PR DESCRIPTION
## Summary
- implement API route `/api/leaderboard/{skill}` to fetch rankings for a single skill
- support showing skill leaderboards in the frontend
- allow clicking a skill on the player view to open its leaderboard
- update docs with new endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c167a1ff0832e8e86aa69cb64e54e