### PR TITLE
refactor: centralize frontend helpers and tidy frontend UX

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,23 +1,6 @@
 // Frontend main application logic for OSRS Hiscores clone
 const LEADERBOARD_LIMIT = 500; // configurable cap for initial view
 const cache = { leaderboard: null, users: null, skillRankings: null, usersFetchedAt: 0 };
-const SKILLS = ['attack', 'defence', 'strength', 'hitpoints', 'ranged', 'prayer', 'magic', 'cooking', 'woodcutting', 'fletching', 'fishing', 'firemaking', 'crafting', 'smithing', 'mining', 'herblore', 'agility', 'thieving', 'slayer', 'farming', 'runecraft', 'hunter', 'construction'];
-
-function $(sel, root = document) { return root.querySelector(sel); }
-function el(tag, cls, children) { const e = document.createElement(tag); if (cls) e.className = cls; if (children) children.forEach(c => e.appendChild(c)); return e; }
-function text(t) { return document.createTextNode(t); }
-
-function toast(msg, type = 'info', timeout = 3000) {
-    const container = $('#toastContainer');
-    const div = el('div', type === 'error' ? 'toast toast--error' : 'toast');
-    div.textContent = msg;
-    container.appendChild(div);
-    setTimeout(() => div.remove(), timeout);
-}
-
-function setTheme(theme) { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('theme', theme); updateThemeToggle(); }
-function toggleTheme() { const cur = localStorage.getItem('theme') || 'dark'; setTheme(cur === 'light' ? 'dark' : 'light'); }
-function updateThemeToggle() { const btn = $('#themeToggle'); if (!btn) return; btn.innerHTML = ''; const theme = localStorage.getItem('theme') || 'dark'; const icon = document.createElement('i'); icon.setAttribute('data-lucide', theme === 'light' ? 'moon' : 'sun'); btn.appendChild(icon); if (window.lucide) window.lucide.createIcons(); }
 
 // fetchJSON & API_BASE now provided by common.js
 async function loadLeaderboard(force = false) { if (cache.leaderboard && !force) return cache.leaderboard; cache.leaderboard = await fetchJSON(`/api/leaderboard?limit=${LEADERBOARD_LIMIT}`); return cache.leaderboard; }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,67 +1,96 @@
 // Frontend main application logic for OSRS Hiscores clone
 const LEADERBOARD_LIMIT = 500; // configurable cap for initial view
-const cache = { leaderboard: null, users: null, skillRankings: null, usersFetchedAt: 0 };
+const cache = {
+  leaderboard: null,
+  users: null,
+  skillRankings: null,
+  usersFetchedAt: 0,
+};
 
 // fetchJSON & API_BASE now provided by common.js
-async function loadLeaderboard(force = false) { if (cache.leaderboard && !force) return cache.leaderboard; cache.leaderboard = await fetchJSON(`/api/leaderboard?limit=${LEADERBOARD_LIMIT}`); return cache.leaderboard; }
-async function loadUsers(force = false) { if (cache.users && !force && (Date.now() - cache.usersFetchedAt < 60_000)) return cache.users; cache.users = await fetchJSON('/api/users'); cache.usersFetchedAt = Date.now(); return cache.users; }
+async function loadLeaderboard(force = false) {
+  if (cache.leaderboard && !force) return cache.leaderboard;
+  cache.leaderboard = await fetchJSON(
+    `/api/leaderboard?limit=${LEADERBOARD_LIMIT}`,
+  );
+  return cache.leaderboard;
+}
+async function loadUsers(force = false) {
+  if (cache.users && !force && Date.now() - cache.usersFetchedAt < 60_000)
+    return cache.users;
+  cache.users = await fetchJSON("/api/users");
+  cache.usersFetchedAt = Date.now();
+  return cache.users;
+}
 async function loadSkillRankings(force = false) {
-    if (cache.skillRankings && !force) return cache.skillRankings;
-    cache.skillRankings = await fetchJSON('/api/skill-rankings');
-    return cache.skillRankings;
+  if (cache.skillRankings && !force) return cache.skillRankings;
+  cache.skillRankings = await fetchJSON("/api/skill-rankings");
+  return cache.skillRankings;
 }
 
 function getUserSkillRank(skillRankings, username, skill) {
-    if (!skillRankings || !skillRankings.rankings || !skillRankings.rankings[skill]) return null;
-    const skillData = skillRankings.rankings[skill];
-    const playerData = skillData.find(p => p.username === username);
-    return playerData ? playerData.rank : null;
+  if (
+    !skillRankings ||
+    !skillRankings.rankings ||
+    !skillRankings.rankings[skill]
+  )
+    return null;
+  const skillData = skillRankings.rankings[skill];
+  const playerData = skillData.find((p) => p.username === username);
+  return playerData ? playerData.rank : null;
 }
 
 // ---------- Views ----------
 function renderHomeView() {
-    const root = $('#viewRoot');
-    root.innerHTML = '';
+  const root = $("#viewRoot");
+  root.innerHTML = "";
 
-    const section = el('section', 'flex flex-col gap-6');
+  const section = el("section", "flex flex-col gap-6");
 
-    // Header section
-    const headerDiv = el('div', 'flex items-center justify-between flex-wrap gap-4');
-    headerDiv.appendChild(el('h2', 'text-2xl font-bold flex items-center gap-2 text-foreground', [
-        text('🏆 Overall Leaderboard')
-    ]));
+  // Header section
+  const headerDiv = el(
+    "div",
+    "flex items-center justify-between flex-wrap gap-4",
+  );
+  headerDiv.appendChild(
+    el("h2", "text-2xl font-bold flex items-center gap-2 text-foreground", [
+      text("🏆 Overall Leaderboard"),
+    ]),
+  );
 
-    const statsDiv = el('div', 'flex gap-3 flex-wrap text-muted text-sm');
-    statsDiv.appendChild(el('div', 'badge', [text('Top 100 Players')]));
-    section.appendChild(headerDiv);
+  const statsDiv = el("div", "flex gap-3 flex-wrap text-muted text-sm");
+  statsDiv.appendChild(el("div", "badge", [text("Top 100 Players")]));
+  section.appendChild(headerDiv);
 
-    // Table wrapper with OSRS styling
-    const tableWrap = el('div', 'osrs-table');
-    const table = el('table', 'min-w-full');
-    table.innerHTML = `<thead><tr><th>Rank</th><th class="text-left">Player</th><th>Total Level</th><th>Total Experience</th></tr></thead><tbody></tbody>`;
-    tableWrap.appendChild(table);
-    section.appendChild(tableWrap);
-    root.appendChild(section);
+  // Table wrapper with OSRS styling
+  const tableWrap = el("div", "osrs-table");
+  const table = el("table", "min-w-full");
+  table.innerHTML = `<thead><tr><th>Rank</th><th class="text-left">Player</th><th>Total Level</th><th>Total Experience</th></tr></thead><tbody></tbody>`;
+  tableWrap.appendChild(table);
+  section.appendChild(tableWrap);
+  root.appendChild(section);
 
-    const tbody = table.querySelector('tbody');
-    tbody.innerHTML = '<tr><td colspan="4" class="text-center text-muted py-8">⏳ Loading leaderboard...</td></tr>';
+  const tbody = table.querySelector("tbody");
+  tbody.innerHTML =
+    '<tr><td colspan="4" class="text-center text-muted py-8">⏳ Loading leaderboard...</td></tr>';
 
-    loadLeaderboard().then(data => {
-        tbody.innerHTML = '';
-        data.players.slice(0, 100).forEach((p, index) => {
-            const tr = document.createElement('tr');
+  loadLeaderboard()
+    .then((data) => {
+      tbody.innerHTML = "";
+      data.players.slice(0, 100).forEach((p, index) => {
+        const tr = document.createElement("tr");
 
-            // Add rank indicators for top 3
-            let rankDisplay = p.rank;
-            if (p.rank === 1) rankDisplay = '🥇 ' + p.rank;
-            else if (p.rank === 2) rankDisplay = '🥈 ' + p.rank;
-            else if (p.rank === 3) rankDisplay = '🥉 ' + p.rank;
+        // Add rank indicators for top 3
+        let rankDisplay = p.rank;
+        if (p.rank === 1) rankDisplay = "🥇 " + p.rank;
+        else if (p.rank === 2) rankDisplay = "🥈 " + p.rank;
+        else if (p.rank === 3) rankDisplay = "🥉 " + p.rank;
 
-            if (p.rank === 1) tr.classList.add('rank-1');
-            else if (p.rank === 2) tr.classList.add('rank-2');
-            else if (p.rank === 3) tr.classList.add('rank-3');
+        if (p.rank === 1) tr.classList.add("rank-1");
+        else if (p.rank === 2) tr.classList.add("rank-2");
+        else if (p.rank === 3) tr.classList.add("rank-3");
 
-            tr.innerHTML = `
+        tr.innerHTML = `
                 <td class="text-center font-bold">${rankDisplay}</td>
                 <td>
                     <button class="username-link" data-user="${p.username}" aria-label="View ${p.username} stats">${p.username}</button>
@@ -69,79 +98,108 @@ function renderHomeView() {
                 <td class="text-center skill-level">${p.totalLevel}</td>
                 <td class="text-right skill-xp">${p.totalXP.toLocaleString()}</td>
             `;
-            tbody.appendChild(tr);
-        });
+        tbody.appendChild(tr);
+      });
 
-        // Update stats
-        if (data.totalPlayers > 0) {
-            statsDiv.innerHTML = '';
-            statsDiv.appendChild(el('div', 'badge', [text(`${data.totalPlayers} total players`)]));
-            headerDiv.appendChild(statsDiv);
-        }
-    }).catch(e => {
-        const htmlLike = /Received HTML|Unexpected content-type/.test(e.message);
-        const hint = htmlLike ? '<div class="mt-4 text-sm text-left max-w-lg mx-auto p-4 bg-layer2 rounded border-l-4 border-accent">⚠️ <strong>Backend not mounted:</strong><br>Verify _worker.js is present at repo root and KV binding HISCORES_KV is configured in Pages project settings. Also ensure deployment finished successfully.<br><br><code class="bg-layer p-1 rounded text-xs">/api/health</code> should return JSON.</div>' : '';
-        tbody.innerHTML = `<tr><td colspan="4" class="text-center py-8"><div class="text-danger font-semibold">❌ ${e.message}</div>${hint}</td></tr>`;
+      // Update stats
+      if (data.totalPlayers > 0) {
+        statsDiv.innerHTML = "";
+        statsDiv.appendChild(
+          el("div", "badge", [text(`${data.totalPlayers} total players`)]),
+        );
+        headerDiv.appendChild(statsDiv);
+      }
+    })
+    .catch((e) => {
+      const htmlLike = /Received HTML|Unexpected content-type/.test(e.message);
+      const hint = htmlLike
+        ? '<div class="mt-4 text-sm text-left max-w-lg mx-auto p-4 bg-layer2 rounded border-l-4 border-accent">⚠️ <strong>Backend not mounted:</strong><br>Verify _worker.js is present at repo root and KV binding HISCORES_KV is configured in Pages project settings. Also ensure deployment finished successfully.<br><br><code class="bg-layer p-1 rounded text-xs">/api/health</code> should return JSON.</div>'
+        : "";
+      tbody.innerHTML = `<tr><td colspan="4" class="text-center py-8"><div class="text-danger font-semibold">❌ ${e.message}</div>${hint}</td></tr>`;
     });
 }
 
-async function loadUser(username) { return fetchJSON('/api/users/' + encodeURIComponent(username)); }
+async function loadUser(username) {
+  return fetchJSON("/api/users/" + encodeURIComponent(username));
+}
 
 function renderUserView(username) {
-    const root = $('#viewRoot');
-    root.innerHTML = '<div class="text-center text-muted py-8">⏳ Loading player data...</div>';
+  const root = $("#viewRoot");
+  root.innerHTML =
+    '<div class="text-center text-muted py-8">⏳ Loading player data...</div>';
 
-    Promise.all([
-        loadUser(username),
-        loadSkillRankings(),
-        loadLeaderboard().catch(() => null)
-    ]).then(([user, skillRankings, leaderboard]) => {
-        const wrap = el('div', 'flex flex-col gap-8');
+  Promise.all([
+    loadUser(username),
+    loadSkillRankings(),
+    loadLeaderboard().catch(() => null),
+  ])
+    .then(([user, skillRankings, leaderboard]) => {
+      const wrap = el("div", "flex flex-col gap-8");
 
-        // User header with enhanced styling
-        const headerSection = el('div', 'bg-layer2 p-6 rounded-lg border-2 border-border-dark');
-        const headerContent = el('div', 'flex items-center justify-between flex-wrap gap-4');
+      // User header with enhanced styling
+      const headerSection = el(
+        "div",
+        "bg-layer2 p-6 rounded-lg border-2 border-border-dark",
+      );
+      const headerContent = el(
+        "div",
+        "flex items-center justify-between flex-wrap gap-4",
+      );
 
-        const userInfo = el('div', 'flex items-center gap-3 flex-wrap');
-        userInfo.appendChild(el('h3', 'font-bold text-foreground', [text(`⚔️ ${user.username}`)]));
+      const userInfo = el("div", "flex items-center gap-3 flex-wrap");
+      userInfo.appendChild(
+        el("h3", "font-bold text-foreground", [text(`⚔️ ${user.username}`)]),
+      );
 
-        // Calculate combat level (simplified)
-        const attack = user.skills.attack.level;
-        const strength = user.skills.strength.level;
-        const defence = user.skills.defence.level;
-        const hitpoints = user.skills.hitpoints.level;
-        const ranged = user.skills.ranged.level;
-        const magic = user.skills.magic.level;
-        const prayer = user.skills.prayer.level;
+      // Calculate combat level (simplified)
+      const attack = user.skills.attack.level;
+      const strength = user.skills.strength.level;
+      const defence = user.skills.defence.level;
+      const hitpoints = user.skills.hitpoints.level;
+      const ranged = user.skills.ranged.level;
+      const magic = user.skills.magic.level;
+      const prayer = user.skills.prayer.level;
 
-        const combatLevel = Math.floor((defence + hitpoints + Math.floor(prayer / 2)) * 0.25 +
-            Math.max(attack + strength, Math.max(ranged * 1.5, magic * 1.5)) * 0.325);
+      const combatLevel = Math.floor(
+        (defence + hitpoints + Math.floor(prayer / 2)) * 0.25 +
+          Math.max(attack + strength, Math.max(ranged * 1.5, magic * 1.5)) *
+            0.325,
+      );
 
-        // Inline metadata badges next to username
-        const meta = el('div', 'meta-badges text-sm flex items-center gap-2 flex-wrap');
-        meta.appendChild(el('span', 'meta-badge', [text(`Combat Lv. ${combatLevel}`)]));
-        {
-            const ts = user.createdAt || user.updatedAt || null;
-            if (ts) {
-                const createdStr = new Date(ts).toLocaleDateString();
-                meta.appendChild(el('span', 'meta-badge', [text(`User created on ${createdStr}`)]));
-            }
+      // Inline metadata badges next to username
+      const meta = el(
+        "div",
+        "meta-badges text-sm flex items-center gap-2 flex-wrap",
+      );
+      meta.appendChild(
+        el("span", "meta-badge", [text(`Combat Lv. ${combatLevel}`)]),
+      );
+      {
+        const ts = user.createdAt || user.updatedAt || null;
+        if (ts) {
+          const createdStr = new Date(ts).toLocaleDateString();
+          meta.appendChild(
+            el("span", "meta-badge", [text(`User created on ${createdStr}`)]),
+          );
         }
-        userInfo.appendChild(meta);
+      }
+      userInfo.appendChild(meta);
 
-        headerContent.appendChild(userInfo);
-        headerSection.appendChild(headerContent);
-        wrap.appendChild(headerSection);
+      headerContent.appendChild(userInfo);
+      headerSection.appendChild(headerContent);
+      wrap.appendChild(headerSection);
 
-        // Hiscores table (column layout like OSRS)
-        const section = el('section', 'flex flex-col gap-4');
-        const headerRow = el('div', 'flex items-center justify-between');
-        headerRow.appendChild(el('h3', 'text-2xl font-bold text-foreground', [text('📜 Hiscores')]));
-        section.appendChild(headerRow);
+      // Hiscores table (column layout like OSRS)
+      const section = el("section", "flex flex-col gap-4");
+      const headerRow = el("div", "flex items-center justify-between");
+      headerRow.appendChild(
+        el("h3", "text-2xl font-bold text-foreground", [text("📜 Hiscores")]),
+      );
+      section.appendChild(headerRow);
 
-        const tableWrap = el('div', 'osrs-table');
-        const table = el('table', 'min-w-full text-sm');
-        table.innerHTML = `
+      const tableWrap = el("div", "osrs-table");
+      const table = el("table", "min-w-full text-sm");
+      table.innerHTML = `
             <thead>
                 <tr>
             <th class="text-left">Skill</th>
@@ -152,120 +210,231 @@ function renderUserView(username) {
             </thead>
             <tbody></tbody>
         `;
-        tableWrap.appendChild(table);
-        section.appendChild(tableWrap);
-        wrap.appendChild(section);
+      tableWrap.appendChild(table);
+      section.appendChild(tableWrap);
+      wrap.appendChild(section);
 
-        const tbody = table.querySelector('tbody');
+      const tbody = table.querySelector("tbody");
 
-        // Determine overall rank from leaderboard (if available)
-        let overallRank = null;
-        if (leaderboard && leaderboard.players) {
-            const found = leaderboard.players.find(p => p.username === user.username);
-            if (found) overallRank = found.rank;
+      // Determine overall rank from leaderboard (if available)
+      let overallRank = null;
+      if (leaderboard && leaderboard.players) {
+        const found = leaderboard.players.find(
+          (p) => p.username === user.username,
+        );
+        if (found) overallRank = found.rank;
+      }
+
+      // Removed overall totals row per request; focus on per-skill stats only
+
+      // Per-skill rows
+      SKILLS.forEach((skillName) => {
+        const skill = user.skills[skillName];
+        const rank = getUserSkillRank(skillRankings, username, skillName);
+
+        const tr = document.createElement("tr");
+
+        // Decorative highlight for top 3 ranks
+        if (rank === 1) tr.classList.add("rank-1");
+        else if (rank === 2) tr.classList.add("rank-2");
+        else if (rank === 3) tr.classList.add("rank-3");
+
+        // Clickable if any meaningful progress
+        const baseXP = skillName === "hitpoints" ? 1154 : 0;
+        const isClickable =
+          (skill?.level || 1) > 1 || (skill?.xp || 0) > baseXP;
+        if (isClickable) {
+          tr.classList.add("clickable");
+          tr.addEventListener("click", () => {
+            window.open(
+              `skill-hiscores.html?skill=${skillName}#skill=${skillName}`,
+              "_blank",
+            );
+          });
         }
 
-        // Removed overall totals row per request; focus on per-skill stats only
+        const iconUrl = window.getSkillIcon(skillName);
+        const nameCell = document.createElement("td");
+        nameCell.className = "text-left";
+        nameCell.innerHTML = `${iconUrl ? `<img src="${iconUrl}" class="skill-icon skill-icon--sm" alt="${skillName}">` : ""}<span class="skill-name text-capitalize">${skillName}</span>`;
 
-        // Per-skill rows
-        SKILLS.forEach(skillName => {
-            const skill = user.skills[skillName];
-            const rank = getUserSkillRank(skillRankings, username, skillName);
+        const lvl = skill?.level ?? 1;
+        const xp = skill?.xp ?? 0;
 
-            const tr = document.createElement('tr');
+        tr.appendChild(nameCell);
+        tr.appendChild(
+          el("td", "text-center skill-level", [text(String(lvl))]),
+        );
+        tr.appendChild(
+          el("td", "text-right skill-xp", [text(xp.toLocaleString())]),
+        );
+        tr.appendChild(
+          el("td", "text-center skill-rank", [text(rank ? `#${rank}` : "—")]),
+        );
 
-            // Decorative highlight for top 3 ranks
-            if (rank === 1) tr.classList.add('rank-1');
-            else if (rank === 2) tr.classList.add('rank-2');
-            else if (rank === 3) tr.classList.add('rank-3');
+        tbody.appendChild(tr);
+      });
 
-            // Clickable if any meaningful progress
-            const baseXP = skillName === 'hitpoints' ? 1154 : 0;
-            const isClickable = (skill?.level || 1) > 1 || (skill?.xp || 0) > baseXP;
-            if (isClickable) {
-                tr.classList.add('clickable');
-                tr.addEventListener('click', () => {
-                    window.open(`skill-hiscores.html?skill=${skillName}#skill=${skillName}`, '_blank');
-                });
-            }
-
-            const iconUrl = window.getSkillIcon(skillName);
-            const nameCell = document.createElement('td');
-            nameCell.className = 'text-left';
-            nameCell.innerHTML = `${iconUrl ? `<img src="${iconUrl}" class="skill-icon skill-icon--sm" alt="${skillName}">` : ''}<span class="skill-name text-capitalize">${skillName}</span>`;
-
-            const lvl = skill?.level ?? 1;
-            const xp = skill?.xp ?? 0;
-
-            tr.appendChild(nameCell);
-            tr.appendChild(el('td', 'text-center skill-level', [text(String(lvl))]));
-            tr.appendChild(el('td', 'text-right skill-xp', [text(xp.toLocaleString())]));
-            tr.appendChild(el('td', 'text-center skill-rank', [text(rank ? `#${rank}` : '—')]));
-
-            tbody.appendChild(tr);
-        });
-
-        root.innerHTML = '';
-        root.appendChild(wrap);
-    }).catch(() => {
-        root.innerHTML = '<div class="text-center py-8"><div class="text-danger text-xl font-semibold">❌ Player not found</div><div class="text-muted mt-2">The player you\'re looking for doesn\'t exist in our database.</div></div>';
+      root.innerHTML = "";
+      root.appendChild(wrap);
+    })
+    .catch(() => {
+      root.innerHTML =
+        '<div class="text-center py-8"><div class="text-danger text-xl font-semibold">❌ Player not found</div><div class="text-muted mt-2">The player you\'re looking for doesn\'t exist in our database.</div></div>';
     });
 }
 
 // ---------- Routing ----------
-function handleRoute() { const hash = location.hash.slice(1); if (!hash) { renderHomeView(); } else if (hash.startsWith('user/')) { const u = decodeURIComponent(hash.split('/')[1]); renderUserView(u); } else { renderHomeView(); } }
+function handleRoute() {
+  const hash = location.hash.slice(1);
+  if (!hash) {
+    renderHomeView();
+  } else if (hash.startsWith("user/")) {
+    const u = decodeURIComponent(hash.split("/")[1]);
+    renderUserView(u);
+  } else {
+    renderHomeView();
+  }
+}
 
 // ---------- Search + Suggestions ----------
 function setupSearch() {
-    const input = $('#playerSearch'); const suggest = $('#searchSuggest'); let debounce; let activeIndex = -1; let currentItems = [];
-    function hideSuggest() { suggest.classList.add('hidden'); suggest.innerHTML = ''; activeIndex = -1; currentItems = []; input.setAttribute('aria-expanded', 'false'); }
-    function renderSuggest(matches) { currentItems = matches; suggest.innerHTML = matches.map((m, i) => `<button role="option" aria-selected="${i === activeIndex}" data-user="${m}" class="block${i === activeIndex ? ' active' : ''}">${m}</button>`).join(''); suggest.classList.remove('hidden'); input.setAttribute('aria-expanded', 'true'); }
-    input.addEventListener('input', () => { clearTimeout(debounce); debounce = setTimeout(async () => { const q = input.value.trim().toLowerCase(); if (!q) { hideSuggest(); return; } try { const list = await loadUsers(); const matches = list.users.filter(u => u.toLowerCase().includes(q)).slice(0, 10); if (!matches.length) { hideSuggest(); return; } activeIndex = -1; renderSuggest(matches); } catch (e) { hideSuggest(); } }, 200); });
-    input.addEventListener('keydown', e => {
-        if (suggest.classList.contains('hidden')) { if (e.key === 'ArrowDown') { e.preventDefault(); } return; }
-        if (e.key === 'Escape') { hideSuggest(); input.blur(); }
-        else if (e.key === 'ArrowDown') { e.preventDefault(); activeIndex = Math.min(currentItems.length - 1, activeIndex + 1); renderSuggest(currentItems); }
-        else if (e.key === 'ArrowUp') { e.preventDefault(); activeIndex = Math.max(0, activeIndex - 1); renderSuggest(currentItems); }
-        else if (e.key === 'Enter') { if (activeIndex >= 0 && currentItems[activeIndex]) { const u = currentItems[activeIndex]; location.hash = 'user/' + encodeURIComponent(u); hideSuggest(); } }
-    });
-    document.addEventListener('click', e => { if (e.target.closest('#searchSuggest button')) { const u = e.target.getAttribute('data-user'); location.hash = 'user/' + encodeURIComponent(u); hideSuggest(); } else if (!e.target.closest('#playerSearch') && !e.target.closest('#searchSuggest')) { hideSuggest(); } });
-    input.addEventListener('change', async () => { const q = input.value.trim().toLowerCase(); if (!q) return; try { const list = await loadUsers(); const found = list.users.find(u => u.toLowerCase() === q); if (found) location.hash = 'user/' + encodeURIComponent(found); } catch (_) { } });
-    // Accessibility attributes
-    input.setAttribute('role', 'combobox');
-    input.setAttribute('aria-autocomplete', 'list');
-    input.setAttribute('aria-expanded', 'false');
-    suggest.setAttribute('role', 'listbox');
+  const input = $("#playerSearch");
+  const suggest = $("#searchSuggest");
+  let debounce;
+  let activeIndex = -1;
+  let currentItems = [];
+  function hideSuggest() {
+    suggest.classList.add("hidden");
+    suggest.innerHTML = "";
+    activeIndex = -1;
+    currentItems = [];
+    input.setAttribute("aria-expanded", "false");
+  }
+  function renderSuggest(matches) {
+    currentItems = matches;
+    suggest.innerHTML = matches
+      .map(
+        (m, i) =>
+          `<button role="option" aria-selected="${i === activeIndex}" data-user="${m}" class="block${i === activeIndex ? " active" : ""}">${m}</button>`,
+      )
+      .join("");
+    suggest.classList.remove("hidden");
+    input.setAttribute("aria-expanded", "true");
+  }
+  input.addEventListener("input", () => {
+    clearTimeout(debounce);
+    debounce = setTimeout(async () => {
+      const q = input.value.trim().toLowerCase();
+      if (!q) {
+        hideSuggest();
+        return;
+      }
+      try {
+        const list = await loadUsers();
+        const matches = list.users
+          .filter((u) => u.toLowerCase().includes(q))
+          .slice(0, 10);
+        if (!matches.length) {
+          hideSuggest();
+          return;
+        }
+        activeIndex = -1;
+        renderSuggest(matches);
+      } catch (e) {
+        hideSuggest();
+      }
+    }, 200);
+  });
+  input.addEventListener("keydown", (e) => {
+    if (suggest.classList.contains("hidden")) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+      }
+      return;
+    }
+    if (e.key === "Escape") {
+      hideSuggest();
+      input.blur();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      activeIndex = Math.min(currentItems.length - 1, activeIndex + 1);
+      renderSuggest(currentItems);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      activeIndex = Math.max(0, activeIndex - 1);
+      renderSuggest(currentItems);
+    } else if (e.key === "Enter") {
+      if (activeIndex >= 0 && currentItems[activeIndex]) {
+        const u = currentItems[activeIndex];
+        location.hash = "user/" + encodeURIComponent(u);
+        hideSuggest();
+      }
+    }
+  });
+  document.addEventListener("click", (e) => {
+    if (e.target.closest("#searchSuggest button")) {
+      const u = e.target.getAttribute("data-user");
+      location.hash = "user/" + encodeURIComponent(u);
+      hideSuggest();
+    } else if (
+      !e.target.closest("#playerSearch") &&
+      !e.target.closest("#searchSuggest")
+    ) {
+      hideSuggest();
+    }
+  });
+  input.addEventListener("change", async () => {
+    const q = input.value.trim().toLowerCase();
+    if (!q) return;
+    try {
+      const list = await loadUsers();
+      const found = list.users.find((u) => u.toLowerCase() === q);
+      if (found) location.hash = "user/" + encodeURIComponent(found);
+    } catch (_) {}
+  });
+  // Accessibility attributes
+  input.setAttribute("role", "combobox");
+  input.setAttribute("aria-autocomplete", "list");
+  input.setAttribute("aria-expanded", "false");
+  suggest.setAttribute("role", "listbox");
 }
 
 // ---------- Delegation ----------
-document.addEventListener('click', e => {
-    const btn = e.target.closest('.username-link');
-    if (btn) {
-        const u = btn.getAttribute('data-user');
-        location.hash = 'user/' + encodeURIComponent(u);
-    }
-    if (e.target.id === 'themeToggle' || e.target.closest('#themeToggle')) toggleTheme();
-    const brand = e.target.closest('.brand-link');
-    if (brand) {
-        e.preventDefault();
-        // SPA: go back to main leaderboard view without reload
-        location.hash = '';
-    }
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest(".username-link");
+  if (btn) {
+    const u = btn.getAttribute("data-user");
+    location.hash = "user/" + encodeURIComponent(u);
+  }
+  if (e.target.id === "themeToggle" || e.target.closest("#themeToggle"))
+    toggleTheme();
+  const brand = e.target.closest(".brand-link");
+  if (brand) {
+    e.preventDefault();
+    // SPA: go back to main leaderboard view without reload
+    location.hash = "";
+  }
 });
 
-window.addEventListener('hashchange', handleRoute);
+window.addEventListener("hashchange", handleRoute);
 
 // Init
 (() => {
-    const saved = localStorage.getItem('theme');
-    const startTheme = saved || (matchMedia && matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-    setTheme(startTheme);
-    setupSearch();
-    handleRoute();
-    // Show current API base in footer
-    const apiSpan = $('#currentApiBase');
-    if (apiSpan && window.API_BASE) {
-        const displayBase = window.API_BASE === location.origin ? 'Same-origin' : window.API_BASE;
-        apiSpan.textContent = displayBase;
-    }
+  const saved = localStorage.getItem("theme");
+  const startTheme =
+    saved ||
+    (matchMedia && matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light");
+  setTheme(startTheme);
+  setupSearch();
+  handleRoute();
+  // Show current API base in footer
+  const apiSpan = $("#currentApiBase");
+  if (apiSpan && window.API_BASE) {
+    const displayBase =
+      window.API_BASE === location.origin ? "Same-origin" : window.API_BASE;
+    apiSpan.textContent = displayBase;
+  }
 })();

--- a/frontend/common.js
+++ b/frontend/common.js
@@ -1,153 +1,198 @@
 // Shared utilities for OSRS Hiscores frontend pages
 // Handles API base configuration plus exposes common DOM helpers and theme utilities
 (function () {
-    // allow overriding API base via ?api=
-    const qApi = new URLSearchParams(location.search).get('api');
-    if (qApi) localStorage.setItem('apiBaseOverride', qApi);
-    let apiBase = (
-        localStorage.getItem('apiBaseOverride') ||
-        document.documentElement.getAttribute('data-api-base') ||
-        location.origin
-    ).replace(/\/$/, '');
+  // allow overriding API base via ?api=
+  const qApi = new URLSearchParams(location.search).get("api");
+  if (qApi) localStorage.setItem("apiBaseOverride", qApi);
+  let apiBase = (
+    localStorage.getItem("apiBaseOverride") ||
+    document.documentElement.getAttribute("data-api-base") ||
+    location.origin
+  ).replace(/\/$/, "");
 
-    function setApiBase(newBase) {
-        if (!newBase) return;
-        apiBase = newBase.replace(/\/$/, '');
-        localStorage.setItem('apiBaseOverride', apiBase);
-        if (window.toast) try { toast('API base set to ' + apiBase + ' – reloading'); } catch (_) { }
-        setTimeout(() => location.reload(), 400);
-    }
-    function clearApiBase() { localStorage.removeItem('apiBaseOverride'); if (window.toast) try { toast('API base override cleared – reloading'); } catch (_) { } setTimeout(() => location.reload(), 400); }
+  function setApiBase(newBase) {
+    if (!newBase) return;
+    apiBase = newBase.replace(/\/$/, "");
+    localStorage.setItem("apiBaseOverride", apiBase);
+    if (window.toast)
+      try {
+        toast("API base set to " + apiBase + " – reloading");
+      } catch (_) {}
+    setTimeout(() => location.reload(), 400);
+  }
+  function clearApiBase() {
+    localStorage.removeItem("apiBaseOverride");
+    if (window.toast)
+      try {
+        toast("API base override cleared – reloading");
+      } catch (_) {}
+    setTimeout(() => location.reload(), 400);
+  }
 
-    async function fetchJSON(path, init) {
-        const url = apiBase + path;
-        const resp = await fetch(url, init);
-        if (!resp.ok) throw new Error('Request failed: ' + resp.status + ' ' + resp.statusText);
-        const ct = resp.headers.get('content-type') || '';
-        const body = await resp.text();
-        try {
-            if (!ct.includes('application/json')) {
-                if (/^\s*</.test(body)) throw new Error('Received HTML instead of JSON from ' + url + ' (point frontend to Worker API).');
-                throw new Error('Unexpected content-type (' + ct + ') from ' + url);
-            }
-            return JSON.parse(body);
-        } catch (e) {
-            if (e instanceof SyntaxError) throw new Error('Invalid JSON from ' + url + ' – first chars: ' + body.slice(0, 60));
-            throw e;
-        }
+  async function fetchJSON(path, init) {
+    const url = apiBase + path;
+    const resp = await fetch(url, init);
+    if (!resp.ok)
+      throw new Error("Request failed: " + resp.status + " " + resp.statusText);
+    const ct = resp.headers.get("content-type") || "";
+    const body = await resp.text();
+    try {
+      if (!ct.includes("application/json")) {
+        if (/^\s*</.test(body))
+          throw new Error(
+            "Received HTML instead of JSON from " +
+              url +
+              " (point frontend to Worker API).",
+          );
+        throw new Error("Unexpected content-type (" + ct + ") from " + url);
+      }
+      return JSON.parse(body);
+    } catch (e) {
+      if (e instanceof SyntaxError)
+        throw new Error(
+          "Invalid JSON from " + url + " – first chars: " + body.slice(0, 60),
+        );
+      throw e;
     }
+  }
 
-    // -------- DOM & Theme helpers --------
-    function $(sel, root = document) {
-        return root.querySelector(sel);
-    }
-    function el(tag, cls, children) {
-        const e = document.createElement(tag);
-        if (cls) e.className = cls;
-        if (children) children.forEach(c => e.appendChild(c));
-        return e;
-    }
-    function text(t) {
-        return document.createTextNode(t);
-    }
+  // -------- DOM & Theme helpers --------
+  function $(sel, root = document) {
+    return root.querySelector(sel);
+  }
+  function el(tag, cls, children) {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (children) children.forEach((c) => e.appendChild(c));
+    return e;
+  }
+  function text(t) {
+    return document.createTextNode(t);
+  }
 
-    function toast(msg, type = 'info', timeout = 3000) {
-        const container = $('#toastContainer');
-        const div = el('div', type === 'error' ? 'toast toast--error' : 'toast');
-        div.textContent = msg;
-        container.appendChild(div);
-        setTimeout(() => div.remove(), timeout);
-    }
+  function toast(msg, type = "info", timeout = 3000) {
+    const container = $("#toastContainer");
+    const div = el("div", type === "error" ? "toast toast--error" : "toast");
+    div.textContent = msg;
+    container.appendChild(div);
+    setTimeout(() => div.remove(), timeout);
+  }
 
-    function setTheme(theme) {
-        document.documentElement.setAttribute('data-theme', theme);
-        localStorage.setItem('theme', theme);
-        updateThemeToggle();
-    }
-    function toggleTheme() {
-        const cur = localStorage.getItem('theme') || 'dark';
-        setTheme(cur === 'light' ? 'dark' : 'light');
-    }
-    function updateThemeToggle() {
-        const btn = $('#themeToggle');
-        if (!btn) return;
-        btn.innerHTML = '';
-        const icon = document.createElement('i');
-        icon.setAttribute('data-lucide', (localStorage.getItem('theme') || 'dark') === 'light' ? 'moon' : 'sun');
-        btn.appendChild(icon);
-        if (window.lucide) window.lucide.createIcons();
-    }
+  function setTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+    updateThemeToggle();
+  }
+  function toggleTheme() {
+    const cur = localStorage.getItem("theme") || "dark";
+    setTheme(cur === "light" ? "dark" : "light");
+  }
+  function updateThemeToggle() {
+    const btn = $("#themeToggle");
+    if (!btn) return;
+    btn.innerHTML = "";
+    const icon = document.createElement("i");
+    icon.setAttribute(
+      "data-lucide",
+      (localStorage.getItem("theme") || "dark") === "light" ? "moon" : "sun",
+    );
+    btn.appendChild(icon);
+    if (window.lucide) window.lucide.createIcons();
+  }
 
-    // Expose
-    window.API_BASE = apiBase;
-    window.setApiBase = setApiBase;
-    window.clearApiBase = clearApiBase;
-    window.fetchJSON = fetchJSON;
-    window.$ = $;
-    window.el = el;
-    window.text = text;
-    window.toast = toast;
-    window.setTheme = setTheme;
-    window.toggleTheme = toggleTheme;
-    window.updateThemeToggle = updateThemeToggle;
+  // Expose
+  window.API_BASE = apiBase;
+  window.setApiBase = setApiBase;
+  window.clearApiBase = clearApiBase;
+  window.fetchJSON = fetchJSON;
+  window.$ = $;
+  window.el = el;
+  window.text = text;
+  window.toast = toast;
+  window.setTheme = setTheme;
+  window.toggleTheme = toggleTheme;
+  window.updateThemeToggle = updateThemeToggle;
 
-    // Skills list and icons
-    const SKILLS = [
-        'attack',
-        'defence',
-        'strength',
-        'hitpoints',
-        'ranged',
-        'prayer',
-        'magic',
-        'cooking',
-        'woodcutting',
-        'fletching',
-        'fishing',
-        'firemaking',
-        'crafting',
-        'smithing',
-        'mining',
-        'herblore',
-        'agility',
-        'thieving',
-        'slayer',
-        'farming',
-        'runecraft',
-        'hunter',
-        'construction'
-    ];
-    window.SKILLS = SKILLS;
+  // Skills list and icons
+  const SKILLS = [
+    "attack",
+    "defence",
+    "strength",
+    "hitpoints",
+    "ranged",
+    "prayer",
+    "magic",
+    "cooking",
+    "woodcutting",
+    "fletching",
+    "fishing",
+    "firemaking",
+    "crafting",
+    "smithing",
+    "mining",
+    "herblore",
+    "agility",
+    "thieving",
+    "slayer",
+    "farming",
+    "runecraft",
+    "hunter",
+    "construction",
+  ];
+  window.SKILLS = SKILLS;
 
-    const SKILL_ICONS = {
-        'attack': 'https://oldschool.runescape.wiki/images/thumb/f/fe/Attack_icon.png/21px-Attack_icon.png',
-        'defence': 'https://oldschool.runescape.wiki/images/thumb/b/b8/Defence_icon.png/21px-Defence_icon.png',
-        'strength': 'https://oldschool.runescape.wiki/images/thumb/1/1b/Strength_icon.png/21px-Strength_icon.png',
-        'hitpoints': 'https://oldschool.runescape.wiki/images/thumb/8/8c/Hitpoints_icon.png/21px-Hitpoints_icon.png',
-        'ranged': 'https://oldschool.runescape.wiki/images/thumb/1/19/Ranged_icon.png/21px-Ranged_icon.png',
-        'prayer': 'https://oldschool.runescape.wiki/images/thumb/f/f2/Prayer_icon.png/21px-Prayer_icon.png',
-        'magic': 'https://oldschool.runescape.wiki/images/thumb/5/5c/Magic_icon.png/21px-Magic_icon.png',
-        'cooking': 'https://oldschool.runescape.wiki/images/thumb/4/43/Cooking_icon.png/21px-Cooking_icon.png',
-        'woodcutting': 'https://oldschool.runescape.wiki/images/thumb/f/f4/Woodcutting_icon.png/21px-Woodcutting_icon.png',
-        'fletching': 'https://oldschool.runescape.wiki/images/thumb/2/23/Fletching_icon.png/21px-Fletching_icon.png',
-        'fishing': 'https://oldschool.runescape.wiki/images/thumb/0/05/Fishing_icon.png/21px-Fishing_icon.png',
-        'firemaking': 'https://oldschool.runescape.wiki/images/thumb/9/9b/Firemaking_icon.png/21px-Firemaking_icon.png',
-        'crafting': 'https://oldschool.runescape.wiki/images/thumb/0/06/Crafting_icon.png/21px-Crafting_icon.png',
-        'smithing': 'https://oldschool.runescape.wiki/images/thumb/d/dd/Smithing_icon.png/21px-Smithing_icon.png',
-        'mining': 'https://oldschool.runescape.wiki/images/thumb/4/4a/Mining_icon.png/21px-Mining_icon.png',
-        'herblore': 'https://oldschool.runescape.wiki/images/thumb/3/34/Herblore_icon.png/21px-Herblore_icon.png',
-        'agility': 'https://oldschool.runescape.wiki/images/thumb/0/0a/Agility_icon.png/21px-Agility_icon.png',
-        'thieving': 'https://oldschool.runescape.wiki/images/thumb/4/4a/Thieving_icon.png/21px-Thieving_icon.png',
-        'slayer': 'https://oldschool.runescape.wiki/images/thumb/2/28/Slayer_icon.png/21px-Slayer_icon.png',
-        'farming': 'https://oldschool.runescape.wiki/images/thumb/f/fc/Farming_icon.png/21px-Farming_icon.png',
-        'runecraft': 'https://oldschool.runescape.wiki/images/thumb/6/63/Runecraft_icon.png/21px-Runecraft_icon.png',
-        'hunter': 'https://oldschool.runescape.wiki/images/thumb/d/dd/Hunter_icon.png/21px-Hunter_icon.png',
-        'construction': 'https://oldschool.runescape.wiki/images/thumb/f/f6/Construction_icon.png/21px-Construction_icon.png'
-    };
+  const SKILL_ICONS = {
+    attack:
+      "https://oldschool.runescape.wiki/images/thumb/f/fe/Attack_icon.png/21px-Attack_icon.png",
+    defence:
+      "https://oldschool.runescape.wiki/images/thumb/b/b8/Defence_icon.png/21px-Defence_icon.png",
+    strength:
+      "https://oldschool.runescape.wiki/images/thumb/1/1b/Strength_icon.png/21px-Strength_icon.png",
+    hitpoints:
+      "https://oldschool.runescape.wiki/images/thumb/8/8c/Hitpoints_icon.png/21px-Hitpoints_icon.png",
+    ranged:
+      "https://oldschool.runescape.wiki/images/thumb/1/19/Ranged_icon.png/21px-Ranged_icon.png",
+    prayer:
+      "https://oldschool.runescape.wiki/images/thumb/f/f2/Prayer_icon.png/21px-Prayer_icon.png",
+    magic:
+      "https://oldschool.runescape.wiki/images/thumb/5/5c/Magic_icon.png/21px-Magic_icon.png",
+    cooking:
+      "https://oldschool.runescape.wiki/images/thumb/4/43/Cooking_icon.png/21px-Cooking_icon.png",
+    woodcutting:
+      "https://oldschool.runescape.wiki/images/thumb/f/f4/Woodcutting_icon.png/21px-Woodcutting_icon.png",
+    fletching:
+      "https://oldschool.runescape.wiki/images/thumb/2/23/Fletching_icon.png/21px-Fletching_icon.png",
+    fishing:
+      "https://oldschool.runescape.wiki/images/thumb/0/05/Fishing_icon.png/21px-Fishing_icon.png",
+    firemaking:
+      "https://oldschool.runescape.wiki/images/thumb/9/9b/Firemaking_icon.png/21px-Firemaking_icon.png",
+    crafting:
+      "https://oldschool.runescape.wiki/images/thumb/0/06/Crafting_icon.png/21px-Crafting_icon.png",
+    smithing:
+      "https://oldschool.runescape.wiki/images/thumb/d/dd/Smithing_icon.png/21px-Smithing_icon.png",
+    mining:
+      "https://oldschool.runescape.wiki/images/thumb/4/4a/Mining_icon.png/21px-Mining_icon.png",
+    herblore:
+      "https://oldschool.runescape.wiki/images/thumb/3/34/Herblore_icon.png/21px-Herblore_icon.png",
+    agility:
+      "https://oldschool.runescape.wiki/images/thumb/0/0a/Agility_icon.png/21px-Agility_icon.png",
+    thieving:
+      "https://oldschool.runescape.wiki/images/thumb/4/4a/Thieving_icon.png/21px-Thieving_icon.png",
+    slayer:
+      "https://oldschool.runescape.wiki/images/thumb/2/28/Slayer_icon.png/21px-Slayer_icon.png",
+    farming:
+      "https://oldschool.runescape.wiki/images/thumb/f/fc/Farming_icon.png/21px-Farming_icon.png",
+    runecraft:
+      "https://oldschool.runescape.wiki/images/thumb/6/63/Runecraft_icon.png/21px-Runecraft_icon.png",
+    hunter:
+      "https://oldschool.runescape.wiki/images/thumb/d/dd/Hunter_icon.png/21px-Hunter_icon.png",
+    construction:
+      "https://oldschool.runescape.wiki/images/thumb/f/f6/Construction_icon.png/21px-Construction_icon.png",
+  };
 
-    function getSkillIcon(skillName) {
-        return SKILL_ICONS[skillName] || '';
-    }
+  function getSkillIcon(skillName) {
+    return SKILL_ICONS[skillName] || "";
+  }
 
-    window.getSkillIcon = getSkillIcon;
+  window.getSkillIcon = getSkillIcon;
 })();

--- a/frontend/common.js
+++ b/frontend/common.js
@@ -1,10 +1,14 @@
-// Shared API base + fetch utilities for OSRS Hiscores frontend
-// When using unified Cloudflare Pages deployment with _worker.js at repo root,
-// the API is same-origin under /api/* and no override is necessary.
+// Shared utilities for OSRS Hiscores frontend pages
+// Handles API base configuration plus exposes common DOM helpers and theme utilities
 (function () {
+    // allow overriding API base via ?api=
     const qApi = new URLSearchParams(location.search).get('api');
     if (qApi) localStorage.setItem('apiBaseOverride', qApi);
-    let apiBase = (localStorage.getItem('apiBaseOverride') || document.documentElement.getAttribute('data-api-base') || location.origin).replace(/\/$/, '');
+    let apiBase = (
+        localStorage.getItem('apiBaseOverride') ||
+        document.documentElement.getAttribute('data-api-base') ||
+        location.origin
+    ).replace(/\/$/, '');
 
     function setApiBase(newBase) {
         if (!newBase) return;
@@ -33,13 +37,88 @@
         }
     }
 
+    // -------- DOM & Theme helpers --------
+    function $(sel, root = document) {
+        return root.querySelector(sel);
+    }
+    function el(tag, cls, children) {
+        const e = document.createElement(tag);
+        if (cls) e.className = cls;
+        if (children) children.forEach(c => e.appendChild(c));
+        return e;
+    }
+    function text(t) {
+        return document.createTextNode(t);
+    }
+
+    function toast(msg, type = 'info', timeout = 3000) {
+        const container = $('#toastContainer');
+        const div = el('div', type === 'error' ? 'toast toast--error' : 'toast');
+        div.textContent = msg;
+        container.appendChild(div);
+        setTimeout(() => div.remove(), timeout);
+    }
+
+    function setTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        updateThemeToggle();
+    }
+    function toggleTheme() {
+        const cur = localStorage.getItem('theme') || 'dark';
+        setTheme(cur === 'light' ? 'dark' : 'light');
+    }
+    function updateThemeToggle() {
+        const btn = $('#themeToggle');
+        if (!btn) return;
+        btn.innerHTML = '';
+        const icon = document.createElement('i');
+        icon.setAttribute('data-lucide', (localStorage.getItem('theme') || 'dark') === 'light' ? 'moon' : 'sun');
+        btn.appendChild(icon);
+        if (window.lucide) window.lucide.createIcons();
+    }
+
     // Expose
     window.API_BASE = apiBase;
     window.setApiBase = setApiBase;
     window.clearApiBase = clearApiBase;
     window.fetchJSON = fetchJSON;
+    window.$ = $;
+    window.el = el;
+    window.text = text;
+    window.toast = toast;
+    window.setTheme = setTheme;
+    window.toggleTheme = toggleTheme;
+    window.updateThemeToggle = updateThemeToggle;
 
-    // Skill icons and utilities
+    // Skills list and icons
+    const SKILLS = [
+        'attack',
+        'defence',
+        'strength',
+        'hitpoints',
+        'ranged',
+        'prayer',
+        'magic',
+        'cooking',
+        'woodcutting',
+        'fletching',
+        'fishing',
+        'firemaking',
+        'crafting',
+        'smithing',
+        'mining',
+        'herblore',
+        'agility',
+        'thieving',
+        'slayer',
+        'farming',
+        'runecraft',
+        'hunter',
+        'construction'
+    ];
+    window.SKILLS = SKILLS;
+
     const SKILL_ICONS = {
         'attack': 'https://oldschool.runescape.wiki/images/thumb/f/fe/Attack_icon.png/21px-Attack_icon.png',
         'defence': 'https://oldschool.runescape.wiki/images/thumb/b/b8/Defence_icon.png/21px-Defence_icon.png',

--- a/frontend/skill-hiscores.js
+++ b/frontend/skill-hiscores.js
@@ -1,15 +1,6 @@
 // Skill Hiscores page logic
 // API_BASE, setApiBase, fetchJSON provided by common.js
-const SKILLS = ['attack', 'defence', 'strength', 'hitpoints', 'ranged', 'prayer', 'magic', 'cooking', 'woodcutting', 'fletching', 'fishing', 'firemaking', 'crafting', 'smithing', 'mining', 'herblore', 'agility', 'thieving', 'slayer', 'farming', 'runecraft', 'hunter', 'construction'];
 const cache = { skillRankings: null };
-
-function $(sel, root = document) { return root.querySelector(sel); }
-function el(tag, cls, children) { const e = document.createElement(tag); if (cls) e.className = cls; if (children) children.forEach(c => e.appendChild(c)); return e; }
-function toast(msg, type = 'info', timeout = 3000) { const c = $('#toastContainer'); const d = el('div', type === 'error' ? 'toast toast--error' : 'toast'); d.textContent = msg; c.appendChild(d); setTimeout(() => d.remove(), timeout); }
-
-function setTheme(theme) { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('theme', theme); updateThemeToggle(); }
-function toggleTheme() { setTheme((localStorage.getItem('theme') || 'dark') === 'light' ? 'dark' : 'light'); }
-function updateThemeToggle() { const btn = $('#themeToggle'); if (!btn) return; btn.innerHTML = ''; const i = document.createElement('i'); i.setAttribute('data-lucide', (localStorage.getItem('theme') || 'dark') === 'light' ? 'moon' : 'sun'); btn.appendChild(i); if (window.lucide) window.lucide.createIcons(); }
 
 // fetchJSON now global (common.js)
 async function loadSkillRankings(force = false) { if (cache.skillRankings && !force) return cache.skillRankings; cache.skillRankings = await fetchJSON('/api/skill-rankings'); return cache.skillRankings; }
@@ -37,24 +28,26 @@ function renderTable() {
 
         const skillIcon = window.getSkillIcon(currentSkill);
 
-        slice.forEach(r => {
-            const tr = document.createElement('tr');
-            if (r.rank === 1) tr.classList.add('rank-1');
-            else if (r.rank === 2) tr.classList.add('rank-2');
-            else if (r.rank === 3) tr.classList.add('rank-3');
+        if (slice.length === 0) {
+            tableBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted py-4">No players found</td></tr>`;
+        } else {
+            slice.forEach(r => {
+                const tr = document.createElement('tr');
+                if (r.rank === 1) tr.classList.add('rank-1');
+                else if (r.rank === 2) tr.classList.add('rank-2');
+                else if (r.rank === 3) tr.classList.add('rank-3');
 
-            const iconHtml = skillIcon ? `<img src="${skillIcon}" class="skill-icon skill-icon--xs" alt="${currentSkill}">` : '';
-
-            tr.innerHTML = `
-                <td class="text-center">${r.rank}</td>
-                <td>
-                    <a class="username-link" href="index.html#user/${encodeURIComponent(r.username)}" aria-label="View ${r.username} overall stats">${r.username}</a>
-                </td>
-                <td class="text-center skill-level">${r.level}</td>
-                <td class="text-right skill-xp">${r.xp.toLocaleString()}</td>
-            `;
-            tableBody.appendChild(tr);
-        });
+                tr.innerHTML = `
+                    <td class="text-center">${r.rank}</td>
+                    <td>
+                        <a class="username-link" href="index.html#user/${encodeURIComponent(r.username)}" aria-label="View ${r.username} overall stats">${r.username}</a>
+                    </td>
+                    <td class="text-center skill-level">${r.level}</td>
+                    <td class="text-right skill-xp">${r.xp.toLocaleString()}</td>
+                `;
+                tableBody.appendChild(tr);
+            });
+        }
 
         // update pagination display
         const num = $('#pageNum'); const tot = $('#pageTotal');

--- a/frontend/skill-hiscores.js
+++ b/frontend/skill-hiscores.js
@@ -3,41 +3,46 @@
 const cache = { skillRankings: null };
 
 // fetchJSON now global (common.js)
-async function loadSkillRankings(force = false) { if (cache.skillRankings && !force) return cache.skillRankings; cache.skillRankings = await fetchJSON('/api/skill-rankings'); return cache.skillRankings; }
+async function loadSkillRankings(force = false) {
+  if (cache.skillRankings && !force) return cache.skillRankings;
+  cache.skillRankings = await fetchJSON("/api/skill-rankings");
+  return cache.skillRankings;
+}
 
-let currentSkill = 'attack';
+let currentSkill = "attack";
 let page = 1;
 let perPage = 50; // fixed page size; can be adjusted if needed
 
 function applyNameFilter(rows) {
-    const q = ($('#filterName')?.value || '').trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter(r => r.username.toLowerCase().includes(q));
+  const q = ($("#filterName")?.value || "").trim().toLowerCase();
+  if (!q) return rows;
+  return rows.filter((r) => r.username.toLowerCase().includes(q));
 }
 
 function renderTable() {
-    loadSkillRankings().then(data => {
-        const rows = data.rankings[currentSkill];
-        const filtered = applyNameFilter(rows);
-        const tableBody = $('#skillTable tbody');
-        tableBody.innerHTML = '';
-        const totalPages = Math.max(1, Math.ceil(filtered.length / perPage));
-        if (page > totalPages) page = totalPages;
-        const start = (page - 1) * perPage;
-        const slice = filtered.slice(start, start + perPage);
+  loadSkillRankings()
+    .then((data) => {
+      const rows = data.rankings[currentSkill];
+      const filtered = applyNameFilter(rows);
+      const tableBody = $("#skillTable tbody");
+      tableBody.innerHTML = "";
+      const totalPages = Math.max(1, Math.ceil(filtered.length / perPage));
+      if (page > totalPages) page = totalPages;
+      const start = (page - 1) * perPage;
+      const slice = filtered.slice(start, start + perPage);
 
-        const skillIcon = window.getSkillIcon(currentSkill);
+      const skillIcon = window.getSkillIcon(currentSkill);
 
-        if (slice.length === 0) {
-            tableBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted py-4">No players found</td></tr>`;
-        } else {
-            slice.forEach(r => {
-                const tr = document.createElement('tr');
-                if (r.rank === 1) tr.classList.add('rank-1');
-                else if (r.rank === 2) tr.classList.add('rank-2');
-                else if (r.rank === 3) tr.classList.add('rank-3');
+      if (slice.length === 0) {
+        tableBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted py-4">No players found</td></tr>`;
+      } else {
+        slice.forEach((r) => {
+          const tr = document.createElement("tr");
+          if (r.rank === 1) tr.classList.add("rank-1");
+          else if (r.rank === 2) tr.classList.add("rank-2");
+          else if (r.rank === 3) tr.classList.add("rank-3");
 
-                tr.innerHTML = `
+          tr.innerHTML = `
                     <td class="text-center">${r.rank}</td>
                     <td>
                         <a class="username-link" href="index.html#user/${encodeURIComponent(r.username)}" aria-label="View ${r.username} overall stats">${r.username}</a>
@@ -45,83 +50,117 @@ function renderTable() {
                     <td class="text-center skill-level">${r.level}</td>
                     <td class="text-right skill-xp">${r.xp.toLocaleString()}</td>
                 `;
-                tableBody.appendChild(tr);
-            });
-        }
+          tableBody.appendChild(tr);
+        });
+      }
 
-        // update pagination display
-        const num = $('#pageNum'); const tot = $('#pageTotal');
-        if (num) num.textContent = String(page);
-        if (tot) tot.textContent = String(totalPages);
+      // update pagination display
+      const num = $("#pageNum");
+      const tot = $("#pageTotal");
+      if (num) num.textContent = String(page);
+      if (tot) tot.textContent = String(totalPages);
 
-        const statsEl = $('#skillStats');
-        if (statsEl && filtered.length) {
-            const top = filtered[0];
-            const highestXp = filtered.slice().sort((a, b) => b.xp - a.xp)[0];
-            const avgLvl = (filtered.reduce((a, x) => a + x.level, 0) / filtered.length).toFixed(2);
-            const skillIconHtml = skillIcon ? `<img src="${skillIcon}" class="skill-icon skill-icon--xs" alt="${currentSkill}">` : '';
-            statsEl.innerHTML = `${skillIconHtml}<strong>${currentSkill.charAt(0).toUpperCase() + currentSkill.slice(1)}</strong> • ${filtered.length} players • Top: ${top.username} (rank ${top.rank}) • Highest XP: ${highestXp.username} (${highestXp.xp.toLocaleString()}) • Avg Lvl: ${avgLvl}`;
-        } else if (statsEl) {
-            statsEl.textContent = 'No results';
-        }
-    }).catch(e => {
-        const htmlLike = /Received HTML|Unexpected content-type/.test(e.message);
-        if (htmlLike) toast('API not mounted under /api - verify _worker.js deployment', 'error');
-        else toast(e.message, 'error');
+      const statsEl = $("#skillStats");
+      if (statsEl && filtered.length) {
+        const top = filtered[0];
+        const highestXp = filtered.slice().sort((a, b) => b.xp - a.xp)[0];
+        const avgLvl = (
+          filtered.reduce((a, x) => a + x.level, 0) / filtered.length
+        ).toFixed(2);
+        const skillIconHtml = skillIcon
+          ? `<img src="${skillIcon}" class="skill-icon skill-icon--xs" alt="${currentSkill}">`
+          : "";
+        statsEl.innerHTML = `${skillIconHtml}<strong>${currentSkill.charAt(0).toUpperCase() + currentSkill.slice(1)}</strong> • ${filtered.length} players • Top: ${top.username} (rank ${top.rank}) • Highest XP: ${highestXp.username} (${highestXp.xp.toLocaleString()}) • Avg Lvl: ${avgLvl}`;
+      } else if (statsEl) {
+        statsEl.textContent = "No results";
+      }
+    })
+    .catch((e) => {
+      const htmlLike = /Received HTML|Unexpected content-type/.test(e.message);
+      if (htmlLike)
+        toast(
+          "API not mounted under /api - verify _worker.js deployment",
+          "error",
+        );
+      else toast(e.message, "error");
     });
 }
 
 // Removed exportCsv and CSV export button handlers
 
-document.addEventListener('click', e => {
-    if (e.target.id === 'themeToggle' || e.target.closest('#themeToggle')) toggleTheme();
-    if (e.target.id === 'prevPage') { if (page > 1) { page--; renderTable(); } }
-    if (e.target.id === 'nextPage') { page++; renderTable(); }
-    if (e.target.id === 'backButton' || e.target.closest && e.target.closest('#backButton')) {
-        e.preventDefault();
-        location.href = 'index.html';
+document.addEventListener("click", (e) => {
+  if (e.target.id === "themeToggle" || e.target.closest("#themeToggle"))
+    toggleTheme();
+  if (e.target.id === "prevPage") {
+    if (page > 1) {
+      page--;
+      renderTable();
     }
+  }
+  if (e.target.id === "nextPage") {
+    page++;
+    renderTable();
+  }
+  if (
+    e.target.id === "backButton" ||
+    (e.target.closest && e.target.closest("#backButton"))
+  ) {
+    e.preventDefault();
+    location.href = "index.html";
+  }
 });
 
 // name filter
-let filterDebounce; function queueFilterRender() { clearTimeout(filterDebounce); filterDebounce = setTimeout(() => { page = 1; renderTable(); }, 150); }
-$('#filterName').addEventListener('input', queueFilterRender);
+let filterDebounce;
+function queueFilterRender() {
+  clearTimeout(filterDebounce);
+  filterDebounce = setTimeout(() => {
+    page = 1;
+    renderTable();
+  }, 150);
+}
+$("#filterName").addEventListener("input", queueFilterRender);
 // removed min/max level filters
-$('#skillSelect').addEventListener('change', () => { currentSkill = $('#skillSelect').value; page = 1; renderTable(); });
+$("#skillSelect").addEventListener("change", () => {
+  currentSkill = $("#skillSelect").value;
+  page = 1;
+  renderTable();
+});
 
 function init() {
-    const select = $('#skillSelect');
-    SKILLS.forEach(s => {
-        const opt = document.createElement('option');
-        opt.value = s;
-        opt.textContent = s.charAt(0).toUpperCase() + s.slice(1);
-        select.appendChild(opt);
-    });
+  const select = $("#skillSelect");
+  SKILLS.forEach((s) => {
+    const opt = document.createElement("option");
+    opt.value = s;
+    opt.textContent = s.charAt(0).toUpperCase() + s.slice(1);
+    select.appendChild(opt);
+  });
 
-    // Check for skill parameter in URL hash or query params
-    const urlParams = new URLSearchParams(location.search);
-    const hashParams = new URLSearchParams(location.hash.slice(1));
-    const skillParam = urlParams.get('skill') || hashParams.get('skill');
+  // Check for skill parameter in URL hash or query params
+  const urlParams = new URLSearchParams(location.search);
+  const hashParams = new URLSearchParams(location.hash.slice(1));
+  const skillParam = urlParams.get("skill") || hashParams.get("skill");
 
-    if (skillParam && SKILLS.includes(skillParam)) {
-        currentSkill = skillParam;
-    }
+  if (skillParam && SKILLS.includes(skillParam)) {
+    currentSkill = skillParam;
+  }
 
-    select.value = currentSkill;
+  select.value = currentSkill;
 
-    const theme = localStorage.getItem('theme') || 'dark';
-    setTheme(theme);
+  const theme = localStorage.getItem("theme") || "dark";
+  setTheme(theme);
 
-    // perPage is fixed; page starts at 1
+  // perPage is fixed; page starts at 1
 
-    // Show current API base in footer
-    const apiSpan = $('#currentApiBase');
-    if (apiSpan && window.API_BASE) {
-        const displayBase = window.API_BASE === location.origin ? 'Same-origin' : window.API_BASE;
-        apiSpan.textContent = displayBase;
-    }
+  // Show current API base in footer
+  const apiSpan = $("#currentApiBase");
+  if (apiSpan && window.API_BASE) {
+    const displayBase =
+      window.API_BASE === location.origin ? "Same-origin" : window.API_BASE;
+    apiSpan.textContent = displayBase;
+  }
 
-    renderTable();
+  renderTable();
 }
 
 init();


### PR DESCRIPTION
## Summary
- expose shared DOM, theme and toast helpers in `common.js` so all pages use a single implementation
- register global `SKILLS` list and remove duplicate constants from individual pages
- show a helpful message when no players match the skill hiscores filter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ba704c8832eb234e6f8bb6fb4ef