### PR TITLE
feat: modernize frontend layout and typography

### DIFF
--- a/frontend/common.js
+++ b/frontend/common.js
@@ -100,6 +100,11 @@
     if (window.lucide) window.lucide.createIcons();
   }
 
+  document.addEventListener("DOMContentLoaded", () => {
+    if (window.lucide) window.lucide.createIcons();
+    updateThemeToggle();
+  });
+
   // Expose
   window.API_BASE = apiBase;
   window.setApiBase = setApiBase;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,10 @@
         <title>OSRS Hiscores Clone</title>
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+            rel="stylesheet"
+        />
         <script>
             // Apply saved theme early (default: dark) to avoid flash
             (function () {
@@ -45,11 +48,13 @@
 
                     <!-- Nav -->
                     <nav class="flex items-center gap-4 text-base font-semibold">
-                        <a href="#" class="nav-pill active" data-view="home">
-                            🏆 Leaderboard
+                        <a href="#" class="nav-pill active" data-view="home" data-tooltip="Overall rankings">
+                            <i data-lucide="trophy" class="w-4 h-4"></i>
+                            <span>Leaderboard</span>
                         </a>
-                        <a href="skill-hiscores.html" class="nav-pill">
-                            ⚡ Skill Hiscores
+                        <a href="skill-hiscores.html" class="nav-pill" data-tooltip="View by skill">
+                            <i data-lucide="zap" class="w-4 h-4"></i>
+                            <span>Skill Hiscores</span>
                         </a>
                     </nav>
                 </div>
@@ -66,17 +71,70 @@
                     </div>
 
                     <button id="themeToggle" class="icon-button" title="Toggle Theme">
-                        🌓
+                        <i data-lucide="sun" class="w-5 h-5"></i>
                     </button>
                 </div>
             </header>
 
-            <main class="flex-1 p-6 container-wrap" id="viewRoot"></main>
+            <main class="flex-1 p-6 container-wrap">
+                <nav aria-label="Breadcrumb" class="breadcrumb mb-4">
+                    <ol>
+                        <li>
+                            <a href="#" class="flex items-center gap-1 hover:text-accent">
+                                <i data-lucide="home" class="w-4 h-4"></i>
+                                Home
+                            </a>
+                        </li>
+                        <li class="breadcrumb-sep">/</li>
+                        <li class="text-foreground">Leaderboard</li>
+                    </ol>
+                </nav>
+                <div class="main-grid">
+                    <aside class="sidebar card">
+                        <nav class="flex flex-col gap-3">
+                            <a href="#" class="flex items-center gap-2 hover:text-accent">
+                                <i data-lucide="list" class="w-4 h-4"></i>
+                                Overview
+                            </a>
+                            <a href="skill-hiscores.html" class="flex items-center gap-2 hover:text-accent">
+                                <i data-lucide="zap" class="w-4 h-4"></i>
+                                Skills
+                            </a>
+                        </nav>
+                        <details class="collapse mt-4">
+                            <summary class="font-semibold cursor-pointer flex items-center gap-2">
+                                <i data-lucide="filter" class="w-4 h-4"></i>
+                                Filters
+                            </summary>
+                            <div class="mt-2 text-sm space-y-1">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" checked /> Ranked only
+                                </label>
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" /> Include unranked
+                                </label>
+                            </div>
+                        </details>
+                        <div class="checklist mt-4">
+                            <h2 class="text-sm font-semibold mb-2">Summary</h2>
+                            <ul class="space-y-1">
+                                <li class="flex items-center gap-2">
+                                    <input type="checkbox" checked /> Leaderboard loaded
+                                </li>
+                                <li class="flex items-center gap-2">
+                                    <input type="checkbox" /> Player selected
+                                </li>
+                            </ul>
+                        </div>
+                    </aside>
+                    <section id="viewRoot" class="space-y-4"></section>
+                </div>
+            </main>
             <footer class="p-4 text-xs text-muted text-center border-t-2 border-border-dark bg-layer site-footer">
                 <div class="flex items-center justify-center gap-4 flex-wrap">
                     <span>⚔️ Mock OSRS Hiscores</span>
                     <span>•</span>
-                    <span>🌩️ Powered by Cloudflare Workers</span>
+                    <span data-tooltip="Serverless platform">🌩️ Powered by Cloudflare Workers</span>
                     <span>•</span>
                     <a href="skill-hiscores.html" class="underline hover:text-accent">Skill Hiscores</a>
                 </div>

--- a/frontend/skill-hiscores.html
+++ b/frontend/skill-hiscores.html
@@ -10,7 +10,10 @@
         <title>Skill Hiscores • OSRS Clone</title>
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+            rel="stylesheet"
+        />
         <script>
             // Apply saved theme early (default: dark) to avoid flash
             (function () {
@@ -44,7 +47,10 @@
                         </a>
                     </h1>
                     <div class="w-px h-6 bg-gold/50"></div>
-                    <span class="text-xl font-semibold text-white/90">⚡ Skill Hiscores</span>
+                    <span class="flex items-center gap-2 text-xl font-semibold text-white/90">
+                        <i data-lucide="zap" class="w-5 h-5"></i>
+                        Skill Hiscores
+                    </span>
                 </div>
 
                 <!-- Controls -->
@@ -66,43 +72,75 @@
 
                     <!-- Theme Toggle -->
                     <button id="themeToggle" class="icon-button" title="Toggle Theme">
-                        🌓
+                        <i data-lucide="sun" class="w-5 h-5"></i>
                     </button>
                 </div>
             </header>
-
-            <main class="flex-1 p-6 flex flex-col gap-6 container-wrap">
-                <div class="osrs-table">
-                    <table class="min-w-full text-sm" id="skillTable">
-                        <thead>
-                            <tr>
-                                <th>Rank</th>
-                                <th class="text-left">Player</th>
-                                <th>Level</th>
-                                <th>Experience</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
-                <div
-                    class="flex items-center justify-between gap-4 text-sm flex-wrap bg-layer2 p-4 rounded-lg border-2 border-border">
-                    <div class="flex items-center gap-3">
-                        <button id="prevPage" class="btn-sm">← Previous</button>
-                        <button id="nextPage" class="btn-sm">Next →</button>
-                    </div>
-                    <div class="font-semibold">
-                        Page <span id="pageNum" class="text-accent">1</span> of <span id="pageTotal"
-                            class="text-accent">1</span>
-                    </div>
-                    <div class="opacity-50">Showing ranked results</div>
+            <main class="flex-1 p-6 container-wrap">
+                <nav aria-label="Breadcrumb" class="breadcrumb mb-4">
+                    <ol>
+                        <li>
+                            <a href="index.html" class="flex items-center gap-1 hover:text-accent">
+                                <i data-lucide="home" class="w-4 h-4"></i>
+                                Home
+                            </a>
+                        </li>
+                        <li class="breadcrumb-sep">/</li>
+                        <li class="text-foreground">Skill Hiscores</li>
+                    </ol>
+                </nav>
+                <div class="main-grid">
+                    <aside class="sidebar card">
+                        <nav class="flex flex-col gap-3">
+                            <a href="index.html" class="flex items-center gap-2 hover:text-accent">
+                                <i data-lucide="trophy" class="w-4 h-4"></i>
+                                Overall
+                            </a>
+                        </nav>
+                        <details class="collapse mt-4">
+                            <summary class="font-semibold cursor-pointer flex items-center gap-2">
+                                <i data-lucide="info" class="w-4 h-4"></i>
+                                About
+                            </summary>
+                            <p class="mt-2 text-sm">
+                                Rankings for individual skills with optional filters.
+                            </p>
+                        </details>
+                    </aside>
+                    <section class="space-y-6">
+                        <div class="osrs-table">
+                            <table class="min-w-full text-sm" id="skillTable">
+                                <thead>
+                                    <tr>
+                                        <th>Rank</th>
+                                        <th class="text-left">Player</th>
+                                        <th>Level</th>
+                                        <th>Experience</th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                        <div
+                            class="flex items-center justify-between gap-4 text-sm flex-wrap bg-layer2 p-4 rounded-lg border-2 border-border">
+                            <div class="flex items-center gap-3">
+                                <button id="prevPage" class="btn-sm">← Previous</button>
+                                <button id="nextPage" class="btn-sm">Next →</button>
+                            </div>
+                            <div class="font-semibold">
+                                Page <span id="pageNum" class="text-accent">1</span> of <span id="pageTotal"
+                                    class="text-accent">1</span>
+                            </div>
+                            <div class="opacity-50">Showing ranked results</div>
+                        </div>
+                    </section>
                 </div>
             </main>
             <footer class="p-4 text-xs text-muted text-center border-t-2 border-border-dark bg-layer site-footer">
                 <div class="flex items-center justify-center gap-4 flex-wrap">
                     <span>⚔️ Mock OSRS Hiscores</span>
                     <span>•</span>
-                    <span>🌩️ Powered by Cloudflare Workers</span>
+                    <span data-tooltip="Serverless platform">🌩️ Powered by Cloudflare Workers</span>
                 </div>
                 <div class="mt-2 opacity-60 text-xs">
                     API: <span id="currentApiBase"></span>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -14,8 +14,8 @@
   --color-input: #ffffff;
   --color-danger: #dc2626;
   --color-success: #16a34a;
-  --root-font-scale: 0.85;
-  --body-font-scale: 0.9;
+  --root-font-scale: 1;
+  --body-font-scale: 1;
   --shadow-sm: 0 2px 4px rgba(45, 24, 16, 0.1), 0 0 0 1px rgba(196, 164, 132, 0.3);
   --shadow-md: 0 4px 6px rgba(45, 24, 16, 0.15), 0 2px 4px rgba(45, 24, 16, 0.06);
   --shadow-lg: 0 10px 15px rgba(45, 24, 16, 0.15), 0 4px 6px rgba(45, 24, 16, 0.05);
@@ -36,8 +36,8 @@
   --color-input: #3d3226;
   --color-danger: #ff6b6b;
   --color-success: #51cf66;
-  --root-font-scale: 0.85;
-  --body-font-scale: 0.9;
+  --root-font-scale: 1;
+  --body-font-scale: 1;
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(92, 77, 58, 0.4);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2);
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.4), 0 4px 6px rgba(0, 0, 0, 0.15);
@@ -48,10 +48,22 @@ html {
 }
 
 body {
-  font-family: "Press Start 2P", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-  font-size: calc(10px * var(--body-font-scale));
-  line-height: 1.4;
-  background: var(--color-bg-surface) radial-gradient(circle at 25% 25%, rgba(196, 164, 132, 0.1) 0, transparent 50%), radial-gradient(circle at 75% 75%, rgba(196, 164, 132, 0.05) 0, transparent 50%);
+  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  font-size: calc(16px * var(--body-font-scale));
+  line-height: 1.6;
+  background: var(--color-bg-surface)
+    radial-gradient(circle at 25% 25%, rgba(196, 164, 132, 0.1) 0, transparent 50%),
+    radial-gradient(circle at 75% 75%, rgba(196, 164, 132, 0.05) 0, transparent 50%);
+}
+
+h1 {
+  font-size: 32px;
+  line-height: 1.3;
+}
+
+h2 {
+  font-size: 24px;
+  line-height: 1.3;
 }
 
 /* --- Layout & Grid --- */
@@ -102,6 +114,100 @@ body {
 
 .grid-auto-fit {
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+/* --- Modern Layout Enhancements --- */
+.main-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .main-grid {
+    grid-template-columns: 220px 1fr;
+  }
+}
+
+.sidebar {
+  position: sticky;
+  top: 1.5rem;
+  align-self: start;
+}
+
+.card {
+  background: var(--color-bg-layer);
+  background-image: linear-gradient(
+    135deg,
+    var(--color-bg-layer),
+    var(--color-bg-layer2)
+  );
+  border-radius: 0.5rem;
+  box-shadow: var(--shadow-md);
+  padding: 1rem;
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-lg);
+}
+
+.breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.breadcrumb-sep {
+  opacity: 0.6;
+}
+
+.collapse summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+}
+
+.collapse summary::-webkit-details-marker {
+  display: none;
+}
+
+.checklist ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.checklist input[type='checkbox'] {
+  accent-color: var(--color-accent);
+}
+
+[data-tooltip] {
+  position: relative;
+  cursor: help;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translate(-50%, 0.5rem);
+  white-space: nowrap;
+  background: var(--color-bg-layer2);
+  color: var(--color-foreground);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: var(--shadow-sm);
+  transition: opacity 0.2s ease;
+  z-index: 10;
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
 }
 
 /* --- Common Property Groupings --- */


### PR DESCRIPTION
## Summary
- Revamp interface with card-based layout, sticky sidebar and breadcrumb navigation
- Introduce Inter font with refined heading hierarchy and tooltips
- Add collapsible filter section, iconography and checklist summaries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d5317e3fc832ead2f51f01098104e