### PR TITLE
Improve responsive layout and navigation

### DIFF
--- a/frontend/achievements.html
+++ b/frontend/achievements.html
@@ -48,33 +48,53 @@
     </head>
 
     <body class="h-full bg-surface text-foreground">
+        <a class="skip-link" href="#mainContent">Skip to main content</a>
         <div class="min-h-full flex flex-col max-w-screen-xl mx-auto">
-            <header class="osrs-header p-4 flex-between flex-wrap gap-4">
-                <!-- Brand & Title -->
-                <div class="flex-items-center gap-4">
-                    <h1 class="flex-items-center gap-2 text-2xl font-extrabold text-white tracking-wide">
+            <header class="osrs-header p-4">
+                <div class="header-inner">
+                    <div class="header-brand">
+                        <button id="siteNavToggle" class="mobile-nav-toggle icon-button" type="button"
+                            aria-expanded="false" aria-controls="siteNav" aria-haspopup="true"
+                            data-toggle-target="#siteNav" data-toggle-breakpoint="900px" data-toggle-focus="true"
+                            title="Toggle navigation">
+                            <span class="sr-only">Toggle navigation</span>
+                            <i data-lucide="menu" class="w-5 h-5"></i>
+                        </button>
                         <a href="index.html"
-                            class="brand-link flex-items-center gap-2 hover:text-gold transition-colors">
+                            class="brand-link flex-items-center gap-2 text-2xl font-extrabold text-white tracking-wide hover:text-gold transition-colors">
                             <span class="text-gold">⚔️ OSRS</span>
                             <span>Hiscores</span>
                         </a>
-                    </h1>
-                    <div class="w-px h-6 bg-gold/50"></div>
-                    <span class="flex-items-center gap-2 text-xl font-semibold text-white/90">
-                        <i data-lucide="trophy" class="w-5 h-5"></i>
-                        Achievements
-                    </span>
-                </div>
+                        <span class="header-subtitle">
+                            <i data-lucide="trophy" class="w-5 h-5" aria-hidden="true"></i>
+                            Achievements
+                        </span>
+                    </div>
 
-                <!-- Controls -->
-                <div class="flex-items-center gap-3">
-                    <!-- Theme Toggle -->
-                    <button id="themeToggle" class="icon-button" title="Toggle Theme">
-                        <i data-lucide="sun" class="w-5 h-5"></i>
-                    </button>
+                    <nav id="siteNav" class="primary-nav" aria-label="Primary">
+                        <a href="index.html" class="nav-pill" data-tooltip="Overall rankings">
+                            <i data-lucide="trophy" class="w-4 h-4"></i>
+                            <span>Leaderboard</span>
+                        </a>
+                        <a href="skill-hiscores.html" class="nav-pill" data-tooltip="View by skill">
+                            <i data-lucide="zap" class="w-4 h-4"></i>
+                            <span>Skill Hiscores</span>
+                        </a>
+                        <a href="achievements.html" class="nav-pill active" aria-current="page"
+                            data-tooltip="Achievement system guide">
+                            <i data-lucide="award" class="w-4 h-4"></i>
+                            <span>Achievements</span>
+                        </a>
+                    </nav>
+
+                    <div class="header-actions">
+                        <button id="themeToggle" class="icon-button" title="Toggle Theme">
+                            <i data-lucide="sun" class="w-5 h-5"></i>
+                        </button>
+                    </div>
                 </div>
             </header>
-            <main class="flex-1 p-6 container-wrap">
+            <main id="mainContent" class="flex-1 p-6 container-wrap">
                 <nav aria-label="Breadcrumb" class="breadcrumb mb-4">
                     <ol>
                         <li>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,20 +31,27 @@
     </head>
 
     <body class="h-full bg-surface text-foreground transition-colors">
+        <a class="skip-link" href="#mainContent">Skip to main content</a>
         <div id="app" class="min-h-full flex flex-col max-w-screen-xl mx-auto">
-            <header class="osrs-header px-6 py-4 flex-between">
-                <!-- Left Section: Logo + Nav -->
-                <div class="flex-items-center gap-8">
-                    <!-- Brand -->
-                    <a href="#"
-                        class="flex-items-center gap-2 text-2xl font-extrabold leading-none hover:text-gold transition-colors">
-                        <span class="text-gold">⚔️ OSRS</span>
-                        <span class="text-white">Hiscores</span>
-                    </a>
+            <header class="osrs-header px-6 py-4">
+                <div class="header-inner">
+                    <div class="header-brand">
+                        <button id="siteNavToggle" class="mobile-nav-toggle icon-button" type="button"
+                            aria-expanded="false" aria-controls="siteNav" aria-haspopup="true"
+                            data-toggle-target="#siteNav" data-toggle-breakpoint="900px" data-toggle-focus="true"
+                            title="Toggle navigation">
+                            <span class="sr-only">Toggle navigation</span>
+                            <i data-lucide="menu" class="w-5 h-5"></i>
+                        </button>
+                        <a href="index.html"
+                            class="brand-link flex-items-center gap-2 text-2xl font-extrabold leading-none hover:text-gold transition-colors">
+                            <span class="text-gold">⚔️ OSRS</span>
+                            <span class="text-white">Hiscores</span>
+                        </a>
+                    </div>
 
-                    <!-- Nav -->
-                    <nav class="flex-items-center gap-4 text-base font-semibold">
-                        <a href="#" class="nav-pill active" data-view="home" data-tooltip="Overall rankings">
+                    <nav id="siteNav" class="primary-nav" aria-label="Primary">
+                        <a href="index.html" class="nav-pill active" aria-current="page" data-tooltip="Overall rankings">
                             <i data-lucide="trophy" class="w-4 h-4"></i>
                             <span>Leaderboard</span>
                         </a>
@@ -57,25 +64,25 @@
                             <span>Achievements</span>
                         </a>
                     </nav>
-                </div>
 
-                <!-- Right Section: Search + Theme -->
-                <div class="flex-items-center gap-3">
-                    <div class="relative flex-items-center">
-                        <input id="playerSearch" type="text" placeholder="Search player..."
-                            class="btn-input px-4 py-2 h-10 rounded-md focus:outline-none focus:ring-2 focus:ring-gold"
-                            aria-label="Search player" autocomplete="off" />
-                        <div id="searchSuggest" class="search-suggestions hidden max-h-64 overflow-auto text-sm">
+                    <div class="header-actions">
+                        <div class="header-search" role="search">
+                            <i data-lucide="search" class="search-icon" aria-hidden="true"></i>
+                            <label for="playerSearch" class="sr-only">Search player</label>
+                            <input id="playerSearch" type="text" placeholder="Search player..."
+                                class="btn-input h-10 rounded-md focus:outline-none focus:ring-2 focus:ring-gold"
+                                autocomplete="off" />
+                            <div id="searchSuggest" class="search-suggestions hidden max-h-64 overflow-auto text-sm"></div>
                         </div>
-                    </div>
 
-                    <button id="themeToggle" class="icon-button" title="Toggle Theme">
-                        <i data-lucide="sun" class="w-5 h-5"></i>
-                    </button>
+                        <button id="themeToggle" class="icon-button" title="Toggle Theme">
+                            <i data-lucide="sun" class="w-5 h-5"></i>
+                        </button>
+                    </div>
                 </div>
             </header>
 
-            <main class="flex-1 p-6 container-wrap">
+            <main id="mainContent" class="flex-1 p-6 container-wrap">
                 <nav aria-label="Breadcrumb" class="breadcrumb mb-4">
                     <ol>
                         <li>

--- a/frontend/skill-hiscores.html
+++ b/frontend/skill-hiscores.html
@@ -31,37 +31,60 @@
     </head>
 
     <body class="h-full bg-surface text-foreground">
+        <a class="skip-link" href="#mainContent">Skip to main content</a>
         <div class="min-h-full flex flex-col max-w-screen-xl mx-auto">
-            <header class="osrs-header p-4 flex-between flex-wrap gap-4">
-                <!-- Brand & Title -->
-                <div class="flex-items-center gap-4">
-                    <h1 class="flex-items-center gap-2 text-2xl font-extrabold text-white tracking-wide">
+            <header class="osrs-header p-4">
+                <div class="header-inner">
+                    <div class="header-brand">
+                        <button id="siteNavToggle" class="mobile-nav-toggle icon-button" type="button"
+                            aria-expanded="false" aria-controls="siteNav" aria-haspopup="true"
+                            data-toggle-target="#siteNav" data-toggle-breakpoint="900px" data-toggle-focus="true"
+                            title="Toggle navigation">
+                            <span class="sr-only">Toggle navigation</span>
+                            <i data-lucide="menu" class="w-5 h-5"></i>
+                        </button>
                         <a href="index.html"
-                            class="brand-link flex-items-center gap-2 hover:text-gold transition-colors">
+                            class="brand-link flex-items-center gap-2 text-2xl font-extrabold text-white tracking-wide hover:text-gold transition-colors">
                             <span class="text-gold">⚔️ OSRS</span>
                             <span>Hiscores</span>
                         </a>
-                    </h1>
-                    <div class="w-px h-6 bg-gold/50"></div>
-                    <span class="flex-items-center gap-2 text-xl font-semibold text-white/90">
-                        <i data-lucide="zap" class="w-5 h-5"></i>
-                        Skill Hiscores
-                    </span>
-                </div>
+                        <span class="header-subtitle">
+                            <i data-lucide="zap" class="w-5 h-5" aria-hidden="true"></i>
+                            Skill Hiscores
+                        </span>
+                    </div>
 
-                <!-- Controls -->
-                <div class="flex-items-center gap-3">
-                    <!-- Search & Skill select -->
-                    <select id="skillSelect" class="btn-input px-3 py-2" aria-label="Select skill"></select>
-                    <input id="filterName" placeholder="Search player..." class="btn-input px-5 py-2 min-w-32" />
+                    <nav id="siteNav" class="primary-nav" aria-label="Primary">
+                        <a href="index.html" class="nav-pill" data-tooltip="Overall rankings">
+                            <i data-lucide="trophy" class="w-4 h-4"></i>
+                            <span>Leaderboard</span>
+                        </a>
+                        <a href="skill-hiscores.html" class="nav-pill active" aria-current="page"
+                            data-tooltip="View by skill">
+                            <i data-lucide="zap" class="w-4 h-4"></i>
+                            <span>Skill Hiscores</span>
+                        </a>
+                        <a href="achievements.html" class="nav-pill" data-tooltip="Achievement system guide">
+                            <i data-lucide="award" class="w-4 h-4"></i>
+                            <span>Achievements</span>
+                        </a>
+                    </nav>
 
-                    <!-- Theme Toggle -->
-                    <button id="themeToggle" class="icon-button" title="Toggle Theme">
-                        <i data-lucide="sun" class="w-5 h-5"></i>
-                    </button>
+                    <div class="header-actions header-actions--stack">
+                        <div class="header-toolbar" role="group" aria-label="Skill filters">
+                            <label for="skillSelect" class="sr-only">Select skill</label>
+                            <select id="skillSelect" class="btn-input" aria-label="Select skill"></select>
+                            <label for="filterName" class="sr-only">Search player</label>
+                            <input id="filterName" placeholder="Search player..." class="btn-input" aria-label="Search player" />
+                        </div>
+
+                        <button id="themeToggle" class="icon-button" title="Toggle Theme">
+                            <i data-lucide="sun" class="w-5 h-5"></i>
+                        </button>
+                    </div>
                 </div>
             </header>
-            <main class="flex-1 p-6 container-wrap">
+            <main id="mainContent" class="flex-1 p-6 container-wrap">
                 <nav aria-label="Breadcrumb" class="breadcrumb mb-4">
                     <ol>
                         <li>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -129,7 +129,8 @@ table th {
 
 .container-wrap {
   max-width: 1600px;
-  padding: 0 1.5rem
+  padding-left: clamp(1rem, 4vw, 3rem);
+  padding-right: clamp(1rem, 4vw, 3rem)
 }
 
 .grid-auto-fit,
@@ -2499,7 +2500,7 @@ footer.site-footer .mt-2 {
 
 .search-suggestions {
   position: absolute;
-  top: 100%;
+  top: calc(100% + 0.35rem);
   left: 0;
   right: 0;
   background: var(--color-bg-layer);
@@ -2786,9 +2787,168 @@ footer.site-footer .mt-2 {
   transition: border-color .2s, box-shadow .2s, background-color .2s
 }
 
+
 .btn-input:focus {
   border-color: var(--color-accent);
   box-shadow: 0 0 0 3px rgba(0, 112, 243, 0.3)
+}
+
+.skip-link {
+  position: absolute;
+  left: 1.5rem;
+  top: -100px;
+  background: var(--color-accent);
+  color: #fff;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: var(--shadow-md);
+  transition: top 0.2s ease, opacity 0.2s ease;
+  opacity: 0;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  top: 1rem;
+  opacity: 1;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.header-inner {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-areas: "brand nav actions";
+  align-items: center;
+  gap: clamp(0.75rem, 1.2vw + 0.5rem, 1.75rem);
+  width: 100%;
+}
+
+.header-brand {
+  grid-area: brand;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(0.5rem, 1vw, 1.25rem);
+  min-width: 0;
+}
+
+.header-brand .brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.header-subtitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: clamp(0.95rem, 1vw + 0.6rem, 1.25rem);
+  font-weight: 600;
+  color: var(--color-foreground);
+  opacity: 0.85;
+  white-space: nowrap;
+}
+
+.mobile-nav-toggle {
+  display: none;
+  margin-right: 0.25rem;
+}
+
+.primary-nav {
+  grid-area: nav;
+  display: flex;
+  align-items: center;
+  gap: clamp(0.5rem, 1vw, 1.35rem);
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-gutter: stable;
+}
+
+.primary-nav .nav-pill {
+  white-space: nowrap;
+}
+
+.header-actions {
+  grid-area: actions;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.header-actions > :not(.header-search) {
+  flex-shrink: 0;
+}
+
+.header-actions > .header-search {
+  flex-shrink: 1;
+}
+
+.header-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1 1 clamp(220px, 30vw, 320px);
+  min-width: 0;
+}
+
+.header-search .btn-input {
+  width: 100%;
+  padding-left: 2.35rem;
+}
+
+.header-search .search-icon {
+  position: absolute;
+  left: 0.85rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-muted);
+  pointer-events: none;
+}
+
+.header-search .search-suggestions {
+  margin-top: 0.35rem;
+}
+
+.header-actions--stack {
+  flex-wrap: wrap;
+}
+
+.header-actions--stack > * {
+  flex-basis: auto;
+}
+
+.header-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.header-toolbar .btn-input,
+.header-toolbar select,
+.header-toolbar input {
+  flex: 1 1 clamp(140px, 22vw, 240px);
+  min-width: clamp(140px, 20vw, 220px);
 }
 
 .modal-overlay {
@@ -3032,7 +3192,7 @@ footer.site-footer .mt-2 {
 
 @media (min-width:768px) {
   .main-grid {
-    grid-template-columns: 220px 1fr
+    grid-template-columns: minmax(0, 1fr)
   }
 
   table td,
@@ -3042,6 +3202,111 @@ footer.site-footer .mt-2 {
 
   .sidebar {
     width: 100%
+  }
+}
+
+@media (min-width:1024px) {
+  .main-grid {
+    grid-template-columns: minmax(240px, clamp(260px, 22vw, 320px)) minmax(0, 1fr)
+  }
+}
+
+@media (min-width:1280px) {
+  .sidebar {
+    position: sticky;
+    top: 1.5rem
+  }
+}
+
+@media (max-width:1100px) {
+  .header-inner {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas: "brand actions" "nav actions";
+    align-items: start;
+  }
+
+  .header-actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width:900px) {
+  .header-inner {
+    grid-template-columns: 1fr auto;
+    grid-template-areas: "brand actions" "nav nav";
+    align-items: start;
+  }
+
+  .header-brand {
+    gap: 0.5rem 0.75rem;
+  }
+
+  .header-subtitle {
+    flex-basis: 100%;
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .primary-nav {
+    display: none;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    margin-top: 0.75rem;
+    border-top: 1px solid var(--color-border-dark);
+    width: 100%;
+  }
+
+  .primary-nav.is-open {
+    display: flex;
+  }
+
+  .mobile-nav-toggle {
+    display: inline-flex;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: stretch;
+    gap: 0.75rem;
+  }
+
+  .header-actions .header-search {
+    flex: 1 1 100%;
+  }
+
+  .header-toolbar {
+    flex: 1 1 100%;
+  }
+}
+
+@media (max-width:640px) {
+  .header-inner {
+    grid-template-columns: 1fr;
+    grid-template-areas: "brand" "actions" "nav";
+    gap: 1rem;
+  }
+
+  .header-brand {
+    justify-content: space-between;
+  }
+
+  .header-actions {
+    justify-content: stretch;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .header-toolbar {
+    width: 100%;
+  }
+
+  .header-toolbar .btn-input,
+  .header-toolbar select,
+  .header-toolbar input {
+    flex: 1 1 100%;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a skip link and responsive header shell with mobile navigation across the index, skill hiscores, and achievements pages
- refresh styling to support the new header layout, adaptive spacing, and sticky sidebars while improving search presentation
- implement shared collapsible toggle logic to drive the mobile menu experience with breakpoint-aware resets

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c999946184832eb45335cc4134597f